### PR TITLE
Generalize section info parsing in transformers

### DIFF
--- a/Sources/WasmTransformer/OutputSections.swift
+++ b/Sources/WasmTransformer/OutputSections.swift
@@ -1,6 +1,9 @@
-typealias RawSection = (
-    startOffset: Int, endOffset: Int
-)
+struct SectionInfo {
+    let startOffset: Int
+    let endOffset: Int
+    let type: SectionType
+    let size: Int
+}
 
 struct TypeSection {
     private(set) var signatures: [FuncSignature] = []
@@ -75,4 +78,13 @@ struct ImportSection {
         try writer.writeBytes(encodeULEB128(UInt32(contentBuffer.bytes().count)))
         try writer.writeBytes(contentBuffer.bytes())
     }
+}
+
+func writeSection<T>(_ type: SectionType, writer: OutputWriter, bodyWriter: (OutputWriter) throws -> T) throws -> T {
+    try writer.writeByte(type.rawValue)
+    let buffer = InMemoryOutputWriter()
+    let result = try bodyWriter(buffer)
+    try writer.writeBytes(encodeULEB128(UInt32(buffer.bytes().count)))
+    try writer.writeBytes(buffer.bytes())
+    return result
 }

--- a/Sources/WasmTransformer/Transformers/CustomSectionStripper.swift
+++ b/Sources/WasmTransformer/Transformers/CustomSectionStripper.swift
@@ -4,28 +4,21 @@ public struct CustomSectionStripper {
     public init() {}
 
     public func transform<Writer: OutputWriter>(_ input: inout InputByteStream, writer: Writer) throws {
-        let maybeMagic = input.read(4)
-        assert(maybeMagic.elementsEqual(magic))
+        input.readHeader()
         try writer.writeBytes(magic)
-        let maybeVersion = input.read(4)
-        assert(maybeVersion.elementsEqual(version))
         try writer.writeBytes(version)
 
         while !input.isEOF {
-            let offset = input.offset
-            let type = input.readUInt8()
-            let size = Int(input.readVarUInt32())
-            let contentStart = input.offset
-            let sectionType = SectionType(rawValue: type)
+            let section = try input.readSectionInfo()
+            input.skip(section.size)
 
-            input.read(size)
-            switch sectionType {
+            switch section.type {
             case .custom:
                 break
             default:
-                try writer.writeBytes(input.bytes[offset..<contentStart + size])
+                try writer.writeBytes(input.bytes[section.startOffset..<section.endOffset])
             }
-            assert(input.offset == contentStart + size)
+            assert(input.offset == section.endOffset)
         }
     }
 }


### PR DESCRIPTION
Currently file header and section info parsing code is duplicated across transformers. It would be great to avoid that and generalize it.

I've added `SectionInfo` struct that can be read with the new `InputByteStream.readSectionInfo` function. I've also added `InputByteStream.readHeader` to provide uniform file header reading, and `InputByteStream.skip` to move the offset without creating new arrays.

`writeSection` function is moved to `OutputSections.swift`, where it's more fitting. Also, I've made a few functions private where they could be private, but were previously internal.