### PR TITLE
Implement a basic section size profiler

### DIFF
--- a/Sources/WasmTransformer/BinaryFormat.swift
+++ b/Sources/WasmTransformer/BinaryFormat.swift
@@ -4,7 +4,7 @@ let version: [UInt8] = [0x01, 0x00, 0x00, 0x00]
 let LIMITS_HAS_MAX_FLAG: UInt8 = 0x1
 let LIMITS_IS_SHARED_FLAG: UInt8 = 0x2
 
-enum SectionType: UInt8 {
+public enum SectionType: UInt8 {
     case custom = 0
     case type = 1
     case `import` = 2

--- a/Sources/WasmTransformer/OutputSections.swift
+++ b/Sources/WasmTransformer/OutputSections.swift
@@ -1,8 +1,8 @@
-struct SectionInfo {
-    let startOffset: Int
-    let endOffset: Int
-    let type: SectionType
-    let size: Int
+public struct SectionInfo: Equatable {
+    public let startOffset: Int
+    public let endOffset: Int
+    public let type: SectionType
+    public let size: Int
 }
 
 struct TypeSection {

--- a/Sources/WasmTransformer/Transformers/SizeProfiler.swift
+++ b/Sources/WasmTransformer/Transformers/SizeProfiler.swift
@@ -1,0 +1,13 @@
+public func sizeProfiler(_ bytes: [UInt8]) throws -> [SectionInfo] {
+    var input = InputByteStream(bytes: bytes)
+    input.readHeader()
+
+    var result = [SectionInfo]()
+    while !input.isEOF {
+        let section = try input.readSectionInfo()
+        result.append(section)
+        input.skip(section.size)
+
+    }
+    return result
+}

--- a/Tests/WasmTransformerTests/SizeProfilerTests.swift
+++ b/Tests/WasmTransformerTests/SizeProfilerTests.swift
@@ -1,0 +1,29 @@
+@testable import WasmTransformer
+import XCTest
+
+final class SizeProfilerTests: XCTestCase {
+    func testSizeProfiler() throws {
+        let wat = """
+        (module
+          (func $add (result i32)
+            (i32.add
+              (i32.const 1)
+              (i32.const 1)
+            )
+          )
+        )
+        """
+
+        let binaryURL = compileWat(wat, options: ["--debug-names"])
+        let binary = try [UInt8](Data(contentsOf: binaryURL))
+        try XCTAssertEqual(
+            sizeProfiler(binary),
+            [
+                .init(startOffset: 8, endOffset: 15, type: .type, size: 5),
+                .init(startOffset: 15, endOffset: 19, type: .function, size: 2),
+                .init(startOffset: 19, endOffset: 30, type: .code, size: 9),
+                .init(startOffset: 30, endOffset: 50, type: .custom, size: 18),
+            ]
+        )
+    }
+}


### PR DESCRIPTION
This allows users of WasmTransformer to get size of every section in a binary. Full size profile for every function in the code section will be implemented in a separate PR.

Depends on #12.