### PR TITLE
Make `TypeSection` public, rename `sizeProfiler`

### DIFF
--- a/Sources/WasmTransformer/BinaryFormat.swift
+++ b/Sources/WasmTransformer/BinaryFormat.swift
@@ -20,7 +20,7 @@ public enum SectionType: UInt8 {
     case dataCount = 12
 }
 
-enum ValueType: UInt8, Equatable {
+public enum ValueType: UInt8, Equatable {
     case i32 = 0x7F
     case i64 = 0x7E
     case f32 = 0x7D
@@ -63,9 +63,9 @@ enum Opcode: Equatable {
     }
 }
 
-struct FuncSignature {
-    let params: [ValueType]
-    let results: [ValueType]
+public struct FuncSignature {
+    public let params: [ValueType]
+    public let results: [ValueType]
     let hasI64: Bool
 
     func lowered() -> FuncSignature {

--- a/Sources/WasmTransformer/InputByteStream.swift
+++ b/Sources/WasmTransformer/InputByteStream.swift
@@ -38,6 +38,10 @@ public struct InputByteStream {
         )
     }
 
+    public mutating func seek(_ offset: Int) {
+        self.offset = offset
+    }
+
     public mutating func skip(_ length: Int) {
         offset += length
     }

--- a/Sources/WasmTransformer/InputByteStream.swift
+++ b/Sources/WasmTransformer/InputByteStream.swift
@@ -1,7 +1,7 @@
 public struct InputByteStream {
-    private(set) var offset: Int
-    let bytes: ArraySlice<UInt8>
-    var isEOF: Bool {
+    public private(set) var offset: Int
+    public let bytes: ArraySlice<UInt8>
+    public var isEOF: Bool {
         offset >= bytes.endIndex
     }
 

--- a/Sources/WasmTransformer/InputByteStream.swift
+++ b/Sources/WasmTransformer/InputByteStream.swift
@@ -38,11 +38,11 @@ public struct InputByteStream {
         )
     }
 
-    mutating func skip(_ length: Int) {
+    public mutating func skip(_ length: Int) {
         offset += length
     }
 
-    mutating func read(_ length: Int) -> ArraySlice<UInt8> {
+    public mutating func read(_ length: Int) -> ArraySlice<UInt8> {
         let result = bytes[offset ..< offset + length]
         offset += length
         return result

--- a/Sources/WasmTransformer/InputStream.swift
+++ b/Sources/WasmTransformer/InputStream.swift
@@ -53,7 +53,7 @@ public struct InputByteStream {
         return byte[byte.startIndex]
     }
 
-    mutating func readVarUInt32() -> UInt32 {
+    public mutating func readVarUInt32() -> UInt32 {
         let (value, advanced) = decodeULEB128(bytes[offset...], UInt32.self)
         offset += advanced
         return value

--- a/Sources/WasmTransformer/Sections.swift
+++ b/Sources/WasmTransformer/Sections.swift
@@ -5,8 +5,22 @@ public struct SectionInfo: Equatable {
     public let size: Int
 }
 
-struct TypeSection {
-    private(set) var signatures: [FuncSignature] = []
+public struct TypeSection {
+    public private(set) var signatures: [FuncSignature] = []
+
+    init() {}
+
+    public init(from input: inout InputByteStream) throws {
+        let count = input.readVarUInt32()
+        for _ in 0 ..< count {
+            let header = input.readUInt8()
+            assert(header == 0x60)
+            let (params, paramsHasI64) = try input.readResultTypes()
+            let (results, resultsHasI64) = try input.readResultTypes()
+            let hasI64 = paramsHasI64 || resultsHasI64
+            signatures.append(FuncSignature(params: params, results: results, hasI64: hasI64))
+        }
+    }
 
     func write<Writer: OutputWriter>(to writer: Writer) throws {
         try writeSection(.type, writer: writer) { buffer in

--- a/Sources/WasmTransformer/Transformers/I64ImportTransformer.swift
+++ b/Sources/WasmTransformer/Transformers/I64ImportTransformer.swift
@@ -26,7 +26,7 @@ public struct I64ImportTransformer {
 
                 switch sectionInfo.type {
                 case .type:
-                    try scan(typeSection: &typeSection, from: &input)
+                    typeSection = try TypeSection(from: &input)
                 case .import:
                     let partialStart = input.bytes.startIndex + sectionInfo.startOffset
                     let partialEnd = contentStart + sectionInfo.size
@@ -101,19 +101,6 @@ public struct I64ImportTransformer {
                 throw Error.unexpectedSection(type)
             }
             assert(input.offset == contentStart + size)
-        }
-    }
-
-    /// Returns indices of types that contains i64 in its signature
-    func scan(typeSection: inout TypeSection, from input: inout InputByteStream) throws {
-        let count = input.readVarUInt32()
-        for _ in 0 ..< count {
-            let header = input.readUInt8()
-            assert(header == 0x60)
-            let (params, paramsHasI64) = try input.readResultTypes()
-            let (results, resultsHasI64) = try input.readResultTypes()
-            let hasI64 = paramsHasI64 || resultsHasI64
-            typeSection.append(signature: FuncSignature(params: params, results: results, hasI64: hasI64))
         }
     }
 

--- a/Sources/WasmTransformer/Transformers/SizeProfiler.swift
+++ b/Sources/WasmTransformer/Transformers/SizeProfiler.swift
@@ -1,13 +1,15 @@
-public func sizeProfiler(_ bytes: [UInt8]) throws -> [SectionInfo] {
-    var input = InputByteStream(bytes: bytes)
-    input.readHeader()
+public extension InputByteStream {
+    mutating func readSectionsInfo() throws -> [SectionInfo] {
+        precondition(offset == bytes.startIndex)
+        readHeader()
 
-    var result = [SectionInfo]()
-    while !input.isEOF {
-        let section = try input.readSectionInfo()
-        result.append(section)
-        input.skip(section.size)
+        var result = [SectionInfo]()
+        while !isEOF {
+            let section = try readSectionInfo()
+            result.append(section)
+            skip(section.size)
 
+        }
+        return result
     }
-    return result
 }

--- a/Tests/WasmTransformerTests/SectionsInfoTests.swift
+++ b/Tests/WasmTransformerTests/SectionsInfoTests.swift
@@ -1,8 +1,8 @@
 @testable import WasmTransformer
 import XCTest
 
-final class SizeProfilerTests: XCTestCase {
-    func testSizeProfiler() throws {
+final class SectionsInfoTests: XCTestCase {
+    func testSectionsInfo() throws {
         let wat = """
         (module
           (func $add (result i32)
@@ -15,9 +15,9 @@ final class SizeProfilerTests: XCTestCase {
         """
 
         let binaryURL = compileWat(wat, options: ["--debug-names"])
-        let binary = try [UInt8](Data(contentsOf: binaryURL))
+        var input = try InputByteStream(bytes: [UInt8](Data(contentsOf: binaryURL)))
         try XCTAssertEqual(
-            sizeProfiler(binary),
+            input.readSectionsInfo(),
             [
                 .init(startOffset: 8, endOffset: 15, type: .type, size: 5),
                 .init(startOffset: 15, endOffset: 19, type: .function, size: 2),


### PR DESCRIPTION
I'm interested in parsing DWARF debug info from custom sections, probably makes sense to implement that outside of this package first. I've made `readVarUInt32` and a few other functions on `InputByteStream` public to reuse that low-level parsing code. It would be great to also make `TypeSection` with function signatures public, as I need access to those in [Gravity](https://github.com/swiftwasm/Gravity/).

I've also moved `sizeProfiler` to `InputByteStream` and renamed it to `readSectionsInfo`, which makes more sense, as it doesn't do any detailed profiling.