### PR TITLE
Make `ModuleReader` public

### DIFF
--- a/Sources/WasmTransformer/BinaryFormat.swift
+++ b/Sources/WasmTransformer/BinaryFormat.swift
@@ -14,7 +14,7 @@ public enum SectionType: UInt8 {
     case global = 6
     case export = 7
     case start = 8
-    case elem = 9
+    case element = 9
     case code = 10
     case data = 11
     case dataCount = 12

--- a/Sources/WasmTransformer/Readers/CodeSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/CodeSectionReader.swift
@@ -27,7 +27,7 @@ struct LocalsReader {
 }
 
 
-struct CodeSectionReader: VectorSectionReader {
+public struct CodeSectionReader: VectorSectionReader {
     var input: InputByteStream
     let count: UInt32
 

--- a/Sources/WasmTransformer/Readers/ElementSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/ElementSectionReader.swift
@@ -17,7 +17,7 @@ struct ElementItemsReader {
     }
 }
 
-struct ElementSectionReader: VectorSectionReader {
+public struct ElementSectionReader: VectorSectionReader {
     var input: InputByteStream
     let count: UInt32
 

--- a/Sources/WasmTransformer/Readers/FunctionSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/FunctionSectionReader.swift
@@ -2,7 +2,7 @@ struct SignatureIndex: Equatable {
     let value: UInt32
 }
 
-struct FunctionSectionReader: VectorSectionReader {
+public struct FunctionSectionReader: VectorSectionReader {
     var input: InputByteStream
     let count: UInt32
 

--- a/Sources/WasmTransformer/Readers/ImportSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/ImportSectionReader.swift
@@ -11,7 +11,7 @@ public enum ImportDescriptor {
     case global(rawBytes: ArraySlice<UInt8>)
 }
 
-struct ImportSectionReader: VectorSectionReader {
+public struct ImportSectionReader: VectorSectionReader {
     var input: InputByteStream
     let count: UInt32
 

--- a/Sources/WasmTransformer/Readers/ModuleReader.swift
+++ b/Sources/WasmTransformer/Readers/ModuleReader.swift
@@ -1,4 +1,4 @@
-enum ModuleSection {
+public enum ModuleSection {
     case type(TypeSectionReader)
     case `import`(ImportSectionReader)
     case function(FunctionSectionReader)
@@ -7,9 +7,9 @@ enum ModuleSection {
     case rawSection(type: SectionType, content: ArraySlice<UInt8>)
 }
 
-struct ModuleReader {
+public struct ModuleReader {
     enum Error: Swift.Error {
-        case invlaidMagic
+        case invalidMagic
     }
     var input: InputByteStream
     var isEOF: Bool { input.isEOF }
@@ -29,7 +29,7 @@ struct ModuleReader {
             return .import(ImportSectionReader(input: input))
         case .function:
             return .function(FunctionSectionReader(input: input))
-        case .elem:
+        case .element:
             return .element(ElementSectionReader(input: input))
         case .code:
             return .code(CodeSectionReader(input: input))

--- a/Sources/WasmTransformer/Readers/SectionReader.swift
+++ b/Sources/WasmTransformer/Readers/SectionReader.swift
@@ -27,11 +27,11 @@ struct VectorSectionIterator<Reader: VectorSectionReader>: IteratorProtocol {
 }
 
 extension VectorSectionReader {
-    __consuming func makeIterator() -> VectorSectionIterator<Self> {
+    __consuming public func makeIterator() -> VectorSectionIterator<Self> {
         VectorSectionIterator(reader: self, count: count)
     }
 
-    func collect() throws -> [Item] {
+    public func collect() throws -> [Item] {
         var items: [Item] = []
         items.reserveCapacity(Int(count))
         for result in self {

--- a/Sources/WasmTransformer/Readers/TypeSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/TypeSectionReader.swift
@@ -1,4 +1,4 @@
-struct TypeSectionReader: VectorSectionReader {
+public struct TypeSectionReader: VectorSectionReader {
     enum Error: Swift.Error {
         case unsupportedTypeDefKind(UInt8)
     }

--- a/Sources/WasmTransformer/Transformers/I64ImportTransformer.swift
+++ b/Sources/WasmTransformer/Transformers/I64ImportTransformer.swift
@@ -51,7 +51,7 @@ public struct I64ImportTransformer: Transformer {
                 case .rawSection(type: .custom, content: let content):
                     copyingSections.append((type: .custom, content: content))
                 case .element:
-                    throw Error.unexpectedSection(SectionType.elem.rawValue)
+                    throw Error.unexpectedSection(SectionType.element.rawValue)
                 case .function(_):
                     throw Error.unexpectedSection(SectionType.function.rawValue)
                 case .code(_):
@@ -217,7 +217,7 @@ private func transformElemSection<Writer: OutputWriter>(
     input: inout ElementSectionReader, writer: inout Writer,
     trampolines: Trampolines, originalFuncCount: Int
 ) throws {
-    try writer.writeVectorSection(type: .elem, count: input.count) { writer in
+    try writer.writeVectorSection(type: .element, count: input.count) { writer in
         for result in input {
             var entry = try result.get()
             try writer.writeBytes(encodeULEB128(entry.flags))


### PR DESCRIPTION
This is needed to fix https://github.com/swiftwasm/Gravity/issues/1, since `TypeSection` is no longer available in WasmTransformer 0.3.0