### PR TITLE
Make `isEOF` and `readSection` public on `ModuleReader`

### DIFF
--- a/Sources/WasmTransformer/Readers/ModuleReader.swift
+++ b/Sources/WasmTransformer/Readers/ModuleReader.swift
@@ -17,12 +17,13 @@ public struct ModuleReader {
         self.input = input
     }
     
-    var isEOF: Bool { input.isEOF }
+    public var isEOF: Bool { input.isEOF }
 
     mutating func readHeader() throws -> ArraySlice<UInt8> {
         return try input.readHeader()
     }
-    mutating func readSection() throws -> ModuleSection {
+
+    public mutating func readSection() throws -> ModuleSection {
         let sectionInfo = try input.readSectionInfo()
         defer {
             input.seek(sectionInfo.endOffset)


### PR DESCRIPTION
Following up on https://github.com/swiftwasm/WasmTransformer/pull/23, this API is needed to fully utilize `ModuleReader` for parsing sections in any code written outside of WasmTransformer.

@kateinoigakukun WDYT of making `ModuleReader` or some of its new nested type conform to `Sequence` instead of making `isEOF` and `readSection` public? To allow either `for section in moduleReader { ... }` or `for section in moduleReader.sections { ... }`?