### PR TITLE
Make `VectorSectionReader` public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 xcuserdata/
 Package.resolved
+.vscode

--- a/Sources/WasmTransformer/Readers/CodeSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/CodeSectionReader.swift
@@ -1,4 +1,4 @@
-struct FunctionBody {
+public struct FunctionBody {
     var input: InputByteStream
     let size: UInt32
     let endOffset: Int
@@ -26,17 +26,16 @@ struct LocalsReader {
     }
 }
 
-
 public struct CodeSectionReader: VectorSectionReader {
     var input: InputByteStream
-    let count: UInt32
+    public let count: UInt32
 
     init(input: InputByteStream) {
         self.input = input
         self.count = self.input.readVarUInt32()
     }
 
-    mutating func read() throws -> FunctionBody {
+    public mutating func read() throws -> FunctionBody {
         let size = input.readVarUInt32()
         let body = FunctionBody(input: input, size: size,
                                 endOffset: input.offset + Int(size))

--- a/Sources/WasmTransformer/Readers/ElementSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/ElementSectionReader.swift
@@ -1,4 +1,4 @@
-struct ElementSegment {
+public struct ElementSegment {
     let flags: UInt32
     let initExpr: ArraySlice<UInt8>
     var items: ElementItemsReader
@@ -19,14 +19,14 @@ struct ElementItemsReader {
 
 public struct ElementSectionReader: VectorSectionReader {
     var input: InputByteStream
-    let count: UInt32
+    public let count: UInt32
 
     init(input: InputByteStream) {
         self.input = input
         self.count = self.input.readVarUInt32()
     }
 
-    mutating func read() throws -> ElementSegment {
+    public mutating func read() throws -> ElementSegment {
         let flags = input.readVarUInt32()
         let initExpr = try input.consumeI32InitExpr()
         let count = input.readVarUInt32()

--- a/Sources/WasmTransformer/Readers/FunctionSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/FunctionSectionReader.swift
@@ -1,17 +1,17 @@
-struct SignatureIndex: Equatable {
+public struct SignatureIndex: Equatable {
     let value: UInt32
 }
 
 public struct FunctionSectionReader: VectorSectionReader {
     var input: InputByteStream
-    let count: UInt32
+    public let count: UInt32
 
     init(input: InputByteStream) {
         self.input = input
         self.count = self.input.readVarUInt32()
     }
 
-    mutating func read() throws -> SignatureIndex {
+    public mutating func read() throws -> SignatureIndex {
         return SignatureIndex(value: input.readVarUInt32())
     }
 }

--- a/Sources/WasmTransformer/Readers/ImportSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/ImportSectionReader.swift
@@ -13,14 +13,14 @@ public enum ImportDescriptor {
 
 public struct ImportSectionReader: VectorSectionReader {
     var input: InputByteStream
-    let count: UInt32
+    public let count: UInt32
 
     init(input: InputByteStream) {
         self.input = input
         self.count = self.input.readVarUInt32()
     }
 
-    mutating func read() throws -> Import {
+    public mutating func read() throws -> Import {
         try input.readImport()
     }
 }

--- a/Sources/WasmTransformer/Readers/ModuleReader.swift
+++ b/Sources/WasmTransformer/Readers/ModuleReader.swift
@@ -11,12 +11,13 @@ public struct ModuleReader {
     enum Error: Swift.Error {
         case invalidMagic
     }
+
     var input: InputByteStream
-    
+
     public init(input: InputByteStream) {
         self.input = input
     }
-    
+
     public var isEOF: Bool { input.isEOF }
 
     mutating func readHeader() throws -> ArraySlice<UInt8> {

--- a/Sources/WasmTransformer/Readers/TypeSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/TypeSectionReader.swift
@@ -4,14 +4,14 @@ public struct TypeSectionReader: VectorSectionReader {
     }
 
     var input: InputByteStream
-    let count: UInt32
+    public let count: UInt32
 
     init(input: InputByteStream) {
         self.input = input
-        self.count = self.input.readVarUInt32()
+        count = self.input.readVarUInt32()
     }
 
-    mutating func read() throws -> FuncSignature {
+    public mutating func read() throws -> FuncSignature {
         let rawKind = input.readUInt8()
         switch rawKind {
         case 0x60:

--- a/Sources/WasmTransformer/Readers/VectorSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/VectorSectionReader.swift
@@ -4,7 +4,7 @@ public protocol VectorSectionReader: Sequence where Element == Result<Item, Erro
     mutating func read() throws -> Item
 }
 
-struct VectorSectionIterator<Reader: VectorSectionReader>: IteratorProtocol {
+public struct VectorSectionIterator<Reader: VectorSectionReader>: IteratorProtocol {
     private(set) var reader: Reader
     private(set) var left: UInt32
     init(reader: Reader, count: UInt32) {
@@ -12,7 +12,7 @@ struct VectorSectionIterator<Reader: VectorSectionReader>: IteratorProtocol {
         self.left = count
     }
     private var end: Bool = false
-    mutating func next() -> Reader.Element? {
+    public mutating func next() -> Reader.Element? {
         guard !end else { return nil }
         guard left != 0 else { return nil }
         let result = Result(catching: { try reader.read() })

--- a/Sources/WasmTransformer/Readers/VectorSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/VectorSectionReader.swift
@@ -1,4 +1,4 @@
-protocol VectorSectionReader: Sequence where Element == Result<Item, Error> {
+public protocol VectorSectionReader: Sequence where Element == Result<Item, Error> {
     associatedtype Item
     var count: UInt32 { get }
     mutating func read() throws -> Item


### PR DESCRIPTION
More changes to make `ModuleReader` fully usable outside of WasmTransformer.