### PR TITLE
Make `value` on `SignatureIndex` public

### DIFF
--- a/Sources/WasmTransformer/Readers/FunctionSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/FunctionSectionReader.swift
@@ -1,5 +1,5 @@
 public struct SignatureIndex: Equatable {
-    let value: UInt32
+    public let value: UInt32
 }
 
 public struct FunctionSectionReader: VectorSectionReader {


### PR DESCRIPTION
This is hopefully the last change needed to make parsing with WasmTransformer outside of its module fully available.