### PR TITLE
Make properties of `FunctionBody` public

### DIFF
--- a/Sources/WasmTransformer/Readers/CodeSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/CodeSectionReader.swift
@@ -1,7 +1,7 @@
 public struct FunctionBody {
-    var input: InputByteStream
+    public internal(set) var input: InputByteStream
     public let size: UInt32
-    let endOffset: Int
+    public let endOffset: Int
 
     func locals() -> LocalsReader {
         LocalsReader(input: input)

--- a/Sources/WasmTransformer/Readers/CodeSectionReader.swift
+++ b/Sources/WasmTransformer/Readers/CodeSectionReader.swift
@@ -1,6 +1,6 @@
 public struct FunctionBody {
     var input: InputByteStream
-    let size: UInt32
+    public let size: UInt32
     let endOffset: Int
 
     func locals() -> LocalsReader {


### PR DESCRIPTION
This allows size profilers to read function code size outside of WasmTransformer.